### PR TITLE
Rename 'RestProperty' and 'SpreadProperty' to 'RestElement' and 'SpreadElement'

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -24,7 +24,7 @@ module.exports = function(acorn) {
             prop.type = "RestElement"
             prop.value = this.toAssignable(prop.argument, true)
           } else {
-            prop.type = "SpreadProperty"
+            prop.type = "SpreadElement"
           }
           node.properties.push(prop)
           continue
@@ -68,7 +68,7 @@ module.exports = function(acorn) {
             var prop = node.properties[i]
             if (prop.kind === "init") {
               this.toAssignable(prop.value, isBinding)
-            } else if (prop.type === "SpreadProperty") {
+            } else if (prop.type === "SpreadElement") {
               prop.value = this.toAssignable(prop.argument, isBinding)
             } else {
               this.raise(prop.key.start, "Object pattern can't contain getter or setter")

--- a/inject.js
+++ b/inject.js
@@ -21,7 +21,7 @@ module.exports = function(acorn) {
         if (this.type === tt.ellipsis) {
           prop = this.parseSpread()
           if (isPattern) {
-            prop.type = "RestProperty"
+            prop.type = "RestElement"
             prop.value = this.toAssignable(prop.argument, true)
           } else {
             prop.type = "SpreadProperty"

--- a/test/test-object-rest-spread.js
+++ b/test/test-object-rest-spread.js
@@ -80,7 +80,7 @@ describe('acorn-object-rest-spread plugin', function() {
             },
             "properties": [
               {
-                "type": "SpreadProperty",
+                "type": "SpreadElement",
                 "start": 9,
                 "end": 13,
                 "loc": {
@@ -231,7 +231,7 @@ describe('acorn-object-rest-spread plugin', function() {
               }
             },
             {
-              "type": "SpreadProperty",
+              "type": "SpreadElement",
               "start": 8,
               "end": 12,
               "loc": {
@@ -349,7 +349,7 @@ describe('acorn-object-rest-spread plugin', function() {
             }
           },
           {
-            "type": "SpreadProperty",
+            "type": "SpreadElement",
             "start": 5,
             "end": 9,
             "loc": {
@@ -431,7 +431,7 @@ describe('acorn-object-rest-spread plugin', function() {
             }
           },
           {
-            "type": "SpreadProperty",
+            "type": "SpreadElement",
             "start": 14,
             "end": 18,
             "loc": {
@@ -761,7 +761,7 @@ describe('acorn-object-rest-spread plugin', function() {
                     }
                   },
                   {
-                    "type": "SpreadProperty",
+                    "type": "SpreadElement",
                     "argument": {
                       "type": "Identifier",
                       "name": "props",

--- a/test/test-object-rest-spread.js
+++ b/test/test-object-rest-spread.js
@@ -563,7 +563,7 @@ describe('acorn-object-rest-spread plugin', function() {
             },
             "properties": [
               {
-                "type": "RestProperty",
+                "type": "RestElement",
                 "start": 5,
                 "end": 9,
                 "loc": {


### PR DESCRIPTION
This is according to the [ESTree spec](https://github.com/estree/estree/blob/master/experimental/rest-spread-properties.md) for those [elements](https://github.com/estree/estree/blob/master/es2015.md#restelement).
This is also according to acorn itself (since array destructuring is already implemented and uses the same types), since it follows ESTree.